### PR TITLE
Implemented kill streaks for ffa gamemode and minimal changes

### DIFF
--- a/src/main/java/dev/revere/alley/base/spawn/command/SpawnCommand.java
+++ b/src/main/java/dev/revere/alley/base/spawn/command/SpawnCommand.java
@@ -30,29 +30,27 @@ public class SpawnCommand extends BaseCommand {
         Profile profile = profileService.getProfile(player.getUniqueId());
         EnumProfileState state = profile.getState();
 
-        if (state == EnumProfileState.FFA) {
-            AbstractFFAMatch ffaMatch = profile.getFfaMatch();
-            if (ffaMatch == null) return;
+        switch (state) {
+            case FFA:
+                AbstractFFAMatch ffaMatch = profile.getFfaMatch();
+                if (ffaMatch == null) return;
 
-            if (ffaMatch.getGameFFAPlayer(player).getState() == EnumFFAState.FIGHTING) {
-                ffaMatch.teleportToSafeZone(player);
-            } else {
-                ffaMatch.leave(player);
-            }
-
-            return;
+                if (ffaMatch.getGameFFAPlayer(player).getState() == EnumFFAState.FIGHTING) {
+                    ffaMatch.teleportToSafeZone(player);
+                } else {
+                    ffaMatch.leave(player);
+                }
+                break;
+            case PLAYING:
+                player.sendMessage(CC.translate("&cYou cannot do this right now."));
+                break;
+            case SPECTATING:
+                profile.getMatch().removeSpectator(player, false);
+                break;
+            default:
+                this.sendToSpawn(player);
+                break;
         }
-
-        if (state == EnumProfileState.PLAYING) {
-            player.sendMessage(CC.translate("&cYou cannot do this right now."));
-            return;
-        }
-
-        if (state == EnumProfileState.SPECTATING) {
-            profile.getMatch().removeSpectator(player, false);
-        }
-
-        this.sendToSpawn(player);
     }
 
     /**

--- a/src/main/java/dev/revere/alley/base/spawn/command/SpawnCommand.java
+++ b/src/main/java/dev/revere/alley/base/spawn/command/SpawnCommand.java
@@ -7,6 +7,8 @@ import dev.revere.alley.api.command.annotation.CommandData;
 import dev.revere.alley.base.hotbar.IHotbarService;
 import dev.revere.alley.base.spawn.ISpawnService;
 import dev.revere.alley.config.IConfigService;
+import dev.revere.alley.game.ffa.AbstractFFAMatch;
+import dev.revere.alley.game.ffa.enums.EnumFFAState;
 import dev.revere.alley.profile.IProfileService;
 import dev.revere.alley.profile.Profile;
 import dev.revere.alley.profile.enums.EnumProfileState;
@@ -26,14 +28,43 @@ public class SpawnCommand extends BaseCommand {
         Player player = args.getPlayer();
         IProfileService profileService = Alley.getInstance().getService(IProfileService.class);
         Profile profile = profileService.getProfile(player.getUniqueId());
-        if (profile.getState() == EnumProfileState.FFA || profile.getState() == EnumProfileState.PLAYING) {
-            player.sendMessage(CC.translate("&cYou cannot teleport to spawn while in this state."));
+        EnumProfileState state = profile.getState();
+
+        if (state == EnumProfileState.FFA) {
+            AbstractFFAMatch ffaMatch = profile.getFfaMatch();
+            if (ffaMatch == null) return;
+
+            if (ffaMatch.getGameFFAPlayer(player).getState() == EnumFFAState.FIGHTING) {
+                ffaMatch.teleportToSafeZone(player);
+            } else {
+                ffaMatch.leave(player);
+            }
+
             return;
         }
 
+        if (state == EnumProfileState.PLAYING) {
+            player.sendMessage(CC.translate("&cYou cannot do this right now."));
+            return;
+        }
+
+        if (state == EnumProfileState.SPECTATING) {
+            profile.getMatch().removeSpectator(player, false);
+        }
+
+        this.sendToSpawn(player);
+    }
+
+    /**
+     * Sends the player to the spawn location and resets their state.
+     *
+     * @param player The player to send to spawn.
+     */
+    private void sendToSpawn(Player player) {
         PlayerUtil.reset(player, false);
-        Alley.getInstance().getService(ISpawnService.class).teleportToSpawn(player);
-        Alley.getInstance().getService(IHotbarService.class).applyHotbarItems(player);
+        this.plugin.getService(ISpawnService.class).teleportToSpawn(player);
+        this.plugin.getService(IHotbarService.class).applyHotbarItems(player);
+
         player.sendMessage(CC.translate(Alley.getInstance().getService(IConfigService.class).getMessagesConfig().getString("spawn.teleported")));
     }
 }

--- a/src/main/java/dev/revere/alley/database/util/MongoUtility.java
+++ b/src/main/java/dev/revere/alley/database/util/MongoUtility.java
@@ -115,6 +115,8 @@ public class MongoUtility {
             Document ffaEntry = new Document();
             ffaEntry.put("kills", entry.getValue().getKills());
             ffaEntry.put("deaths", entry.getValue().getDeaths());
+            ffaEntry.put("killstreak", entry.getValue().getKillstreak());
+            ffaEntry.put("highestKillstreak", entry.getValue().getHighestKillstreak());
             ffaDataDocument.put(entry.getKey(), ffaEntry);
         }
         return ffaDataDocument;
@@ -307,6 +309,8 @@ public class MongoUtility {
             ProfileFFAData ffa = new ProfileFFAData();
             ffa.setKills(ffaEntry.getInteger("kills"));
             ffa.setDeaths(ffaEntry.getInteger("deaths"));
+            ffa.setKillstreak(ffaEntry.getInteger("killstreak", 0));
+            ffa.setHighestKillstreak(ffaEntry.getInteger("highestKillstreak"));
             ffaData.put(entry.getKey(), ffa);
         }
         return ffaData;

--- a/src/main/java/dev/revere/alley/game/ffa/AbstractFFAMatch.java
+++ b/src/main/java/dev/revere/alley/game/ffa/AbstractFFAMatch.java
@@ -2,21 +2,22 @@ package dev.revere.alley.game.ffa;
 
 import dev.revere.alley.Alley;
 import dev.revere.alley.base.arena.AbstractArena;
-import dev.revere.alley.base.combat.CombatService;
 import dev.revere.alley.base.combat.ICombatService;
 import dev.revere.alley.base.hotbar.IHotbarService;
-import dev.revere.alley.base.hotbar.enums.EnumHotbarType;
 import dev.revere.alley.base.kit.Kit;
 import dev.revere.alley.base.spawn.ISpawnService;
 import dev.revere.alley.base.visibility.IVisibilityService;
+import dev.revere.alley.config.IConfigService;
 import dev.revere.alley.game.ffa.player.GameFFAPlayer;
 import dev.revere.alley.profile.IProfileService;
 import dev.revere.alley.profile.Profile;
-import dev.revere.alley.profile.ProfileService;
+import dev.revere.alley.profile.data.impl.ProfileFFAData;
 import dev.revere.alley.profile.enums.EnumProfileState;
 import dev.revere.alley.util.chat.CC;
 import lombok.Getter;
 import lombok.Setter;
+import org.bukkit.Location;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
@@ -77,9 +78,9 @@ public abstract class AbstractFFAMatch {
      * @param player The player who wants to spectate the match.
      */
     public void addSpectator(Player player) {
-        IProfileService profileService = Alley.getInstance().getService(IProfileService.class);
-        IVisibilityService visibilityService = Alley.getInstance().getService(IVisibilityService.class);
-        IHotbarService hotbarService = Alley.getInstance().getService(IHotbarService.class);
+        IProfileService profileService = this.plugin.getService(IProfileService.class);
+        IVisibilityService visibilityService = this.plugin.getService(IVisibilityService.class);
+        IHotbarService hotbarService = this.plugin.getService(IHotbarService.class);
 
         Profile profile = profileService.getProfile(player.getUniqueId());
 
@@ -110,10 +111,10 @@ public abstract class AbstractFFAMatch {
      * @param player The player to remove from the spectator list.
      */
     public void removeSpectator(Player player) {
-        IProfileService profileService = Alley.getInstance().getService(IProfileService.class);
-        IVisibilityService visibilityService = Alley.getInstance().getService(IVisibilityService.class);
-        IHotbarService hotbarService = Alley.getInstance().getService(IHotbarService.class);
-        ISpawnService spawnService = Alley.getInstance().getService(ISpawnService.class);
+        IProfileService profileService = this.plugin.getService(IProfileService.class);
+        IVisibilityService visibilityService = this.plugin.getService(IVisibilityService.class);
+        IHotbarService hotbarService = this.plugin.getService(IHotbarService.class);
+        ISpawnService spawnService = this.plugin.getService(ISpawnService.class);
 
         Profile profile = profileService.getProfile(player.getUniqueId());
         if (profile.getState() == EnumProfileState.SPECTATING) {
@@ -153,17 +154,70 @@ public abstract class AbstractFFAMatch {
      * @param killer The killer
      */
     public void handleCombatLog(Player player, Player killer) {
-        IProfileService profileService = Alley.getInstance().getService(IProfileService.class);
-        ICombatService combatService = Alley.getInstance().getService(ICombatService.class);
+        IProfileService profileService = this.plugin.getService(IProfileService.class);
+        ICombatService combatService = this.plugin.getService(ICombatService.class);
 
         Profile profile = profileService.getProfile(player.getUniqueId());
-        Profile killerProfile = profileService.getProfile(killer.getUniqueId());
+        ProfileFFAData ffaData = profile.getProfileData().getFfaData().get(this.getKit().getName());
+        ffaData.incrementDeaths();
+        ffaData.resetKillstreak();
 
-        profile.getProfileData().getFfaData().get(this.getKit().getName()).incrementDeaths();
-        killerProfile.getProfileData().getFfaData().get(this.getKit().getName()).incrementKills();
+        Profile killerProfile = profileService.getProfile(killer.getUniqueId());
+        ProfileFFAData killerFfaData = killerProfile.getProfileData().getFfaData().get(this.getKit().getName());
+        killerFfaData.incrementKills();
+        killerFfaData.incrementKillstreak();
 
         this.getPlayers().forEach(ffaPlayer -> ffaPlayer.getPlayer().sendMessage(CC.translate("&7(Combat Log) &c" + player.getName() + " has been killed by " + killer.getName() + ".")));
+        this.sendKillstreakAlertMessage(killer);
 
         combatService.resetCombatLog(player);
+    }
+
+    /**
+     * Teleports a player to the safe zone of the FFA arena.
+     *
+     * @param player The player to teleport.
+     */
+    public void teleportToSafeZone(Player player) {
+        ICombatService combatService = this.plugin.getService(ICombatService.class);
+        if (combatService.isPlayerInCombat(player.getUniqueId())) {
+            player.sendMessage(CC.translate("&cYou're still in combat!"));
+            return;
+        }
+
+        Location ffaSpawn = this.arena.getPos1();
+        player.teleport(ffaSpawn);
+        player.sendMessage(CC.translate("&aTeleported to the safe zone!"));
+    }
+
+    /**
+     * Alerts all players in the match if a player reaches a killstreak of 5 or more.
+     *
+     * @param player The player who reached the killstreak.
+     */
+    public void sendKillstreakAlertMessage(Player player) {
+        IConfigService configService = this.plugin.getService(IConfigService.class);
+        FileConfiguration config = configService.getMessagesConfig();
+        if (!config.getBoolean("ffa.killstreak-alert.enabled")) {
+            return;
+        }
+
+        IProfileService profileService = this.plugin.getService(IProfileService.class);
+        Profile profile = profileService.getProfile(player.getUniqueId());
+        ProfileFFAData ffaData = profile.getProfileData().getFfaData().get(this.getKit().getName());
+
+        int interval = config.getInt("ffa.killstreak-alert.interval");
+        List<String> messages = config.getStringList("ffa.killstreak-alert.message");
+
+        if (ffaData.getKillstreak() % interval == 0) {
+            this.getPlayers().forEach(ffaPlayer -> {
+                for (String message : messages) {
+                    ffaPlayer.getPlayer().sendMessage(CC.translate(message
+                            .replace("{player}", player.getName())
+                            .replace("{name-color}", String.valueOf(profile.getNameColor()))
+                            .replace("{killstreak}", String.valueOf(ffaData.getKillstreak()))));
+                }
+            });
+        }
     }
 }

--- a/src/main/java/dev/revere/alley/profile/data/impl/ProfileFFAData.java
+++ b/src/main/java/dev/revere/alley/profile/data/impl/ProfileFFAData.java
@@ -16,12 +16,26 @@ public class ProfileFFAData {
     private int kills = 0;
     private int deaths = 0;
 
+    private int killstreak = 0;
+    private int highestKillstreak = 0;
+
     public void incrementKills() {
         this.kills++;
     }
 
     public void incrementDeaths() {
         this.deaths++;
+    }
+
+    public void incrementKillstreak() {
+        this.killstreak++;
+        if (this.killstreak > this.highestKillstreak) {
+            this.highestKillstreak = this.killstreak;
+        }
+    }
+
+    public void resetKillstreak() {
+        this.killstreak = 0;
     }
 
     /**

--- a/src/main/java/dev/revere/alley/profile/listener/ProfileListener.java
+++ b/src/main/java/dev/revere/alley/profile/listener/ProfileListener.java
@@ -107,7 +107,6 @@ public class ProfileListener implements Listener {
         Profile profile = profileService.getProfile(player.getUniqueId());
 
         if (profile.getState() == EnumProfileState.LOBBY
-                || profile.getState() == EnumProfileState.FFA
                 || profile.getState() == EnumProfileState.EDITING
                 || profile.getState() == EnumProfileState.SPECTATING) {
             if (player.getGameMode() == GameMode.CREATIVE) return;

--- a/src/main/java/dev/revere/alley/provider/scoreboard/IScoreboard.java
+++ b/src/main/java/dev/revere/alley/provider/scoreboard/IScoreboard.java
@@ -5,7 +5,7 @@ import dev.revere.alley.profile.Profile;
 import dev.revere.alley.tool.animation.IAnimationRepository;
 import dev.revere.alley.tool.animation.enums.EnumAnimationType;
 import dev.revere.alley.tool.animation.type.internal.impl.DotAnimationImpl;
-import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
+import dev.revere.alley.tool.reflection.utility.ReflectionUtility;
 import org.bukkit.entity.Player;
 
 import java.util.List;
@@ -49,6 +49,10 @@ public interface IScoreboard {
      * @return The ping of the player.
      */
     default int getPing(Player player) {
-        return ((CraftPlayer) player).getHandle().ping;
+        if (player == null) {
+            return 0;
+        }
+
+        return ReflectionUtility.getPing(player);
     }
 }

--- a/src/main/java/dev/revere/alley/provider/scoreboard/impl/FFAScoreboard.java
+++ b/src/main/java/dev/revere/alley/provider/scoreboard/impl/FFAScoreboard.java
@@ -1,13 +1,11 @@
 package dev.revere.alley.provider.scoreboard.impl;
 
 import dev.revere.alley.Alley;
-import dev.revere.alley.base.combat.CombatService;
 import dev.revere.alley.base.combat.ICombatService;
 import dev.revere.alley.config.IConfigService;
-import dev.revere.alley.feature.level.ILevelService;
 import dev.revere.alley.game.ffa.cuboid.IFFASpawnService;
-import dev.revere.alley.profile.IProfileService;
 import dev.revere.alley.profile.Profile;
+import dev.revere.alley.profile.data.impl.ProfileFFAData;
 import dev.revere.alley.provider.scoreboard.IScoreboard;
 import dev.revere.alley.util.chat.CC;
 import org.bukkit.entity.Player;
@@ -36,6 +34,8 @@ public class FFAScoreboard implements IScoreboard {
      */
     @Override
     public List<String> getLines(Profile profile, Player player) {
+        ProfileFFAData profileFFAData = profile.getProfileData().getFfaData().get(profile.getFfaMatch().getKit().getName());
+
         IFFASpawnService ffaSpawnService = Alley.getInstance().getService(IFFASpawnService.class);
         IConfigService configService = Alley.getInstance().getService(IConfigService.class);
         ICombatService combatService = Alley.getInstance().getService(ICombatService.class);
@@ -58,8 +58,9 @@ public class FFAScoreboard implements IScoreboard {
                         .replaceAll("\\{kit}", profile.getFfaMatch().getKit().getDisplayName())
                         .replaceAll("\\{players}", String.valueOf(profile.getFfaMatch().getPlayers().size()))
                         .replaceAll("\\{zone}", ffaSpawnService.getCuboid().isIn(player) ? "Spawn" : "Warzone")
-                        .replaceAll("\\{kills}", String.valueOf(profile.getProfileData().getFfaData().get(profile.getFfaMatch().getKit().getName()).getKills()))
-                        .replaceAll("\\{deaths}", String.valueOf(profile.getProfileData().getFfaData().get(profile.getFfaMatch().getKit().getName()).getDeaths()))
+                        .replaceAll("\\{ks}", String.valueOf(profileFFAData.getKillstreak()))
+                        .replaceAll("\\{kills}", String.valueOf(profileFFAData.getKills()))
+                        .replaceAll("\\{deaths}", String.valueOf(profileFFAData.getDeaths()))
                         .replaceAll("\\{ping}", String.valueOf(this.getPing(player))));
             }
         }

--- a/src/main/java/dev/revere/alley/provider/scoreboard/impl/match/IMatchScoreboard.java
+++ b/src/main/java/dev/revere/alley/provider/scoreboard/impl/match/IMatchScoreboard.java
@@ -3,6 +3,7 @@ package dev.revere.alley.provider.scoreboard.impl.match;
 import dev.revere.alley.game.match.player.impl.MatchGamePlayerImpl;
 import dev.revere.alley.game.match.player.participant.GameParticipant;
 import dev.revere.alley.profile.Profile;
+import dev.revere.alley.tool.reflection.utility.ReflectionUtility;
 import org.bukkit.ChatColor;
 import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
 import org.bukkit.entity.Player;
@@ -54,6 +55,6 @@ public interface IMatchScoreboard {
             return 0;
         }
 
-        return ((CraftPlayer) player).getHandle().ping;
+        return ReflectionUtility.getPing(player);
     }
 }

--- a/src/main/java/dev/revere/alley/util/PlayerUtil.java
+++ b/src/main/java/dev/revere/alley/util/PlayerUtil.java
@@ -1,7 +1,11 @@
 package dev.revere.alley.util;
 
 import lombok.experimental.UtilityClass;
-import org.bukkit.*;
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -39,6 +43,9 @@ public class PlayerUtil {
 
         player.getActivePotionEffects().forEach(effect -> player.removePotionEffect(effect.getType()));
         player.updateInventory();
+
+        // Clears visuals from the player's model
+        ((CraftPlayer) player).getHandle().getDataWatcher().watch(9, (byte) 0);
 
         if (closeInventory) {
             player.closeInventory();

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -146,7 +146,7 @@ ffa:
     interval: 5 # the required amount of kills to alert ffa players about killstreaks
     message:
       - ""
-      - "&6&l{name-color}{player} &fis on a &6&l{streak} &fkillstreak!"
+      - "&6&l{name-color}{player} &fis on a &6&l{killstreak} &fkillstreak!"
       - ""
 
 player-settings:

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -140,6 +140,15 @@ match:
         - "  &6&l● &f{loser} &7{loser-color}{loser-indicator}{math-loser-elo} &7(&f{old-loser-elo} &7-> &f{new-loser-elo})"
         - ""
 
+ffa:
+  killstreak-alert:
+    enabled: true # Whether to enable killstreak alerts or not
+    interval: 5 # the required amount of kills to alert ffa players about killstreaks
+    message:
+      - ""
+      - "&6&l{name-color}{player} &fis on a &6&l{streak} &fkillstreak!"
+      - ""
+
 player-settings:
   party-invites: "&aYou've {status} &aparty invites."
   party-messages: "&aYou've {status} &aparty messages."


### PR DESCRIPTION
This pull request adds a killstreak system to the FFA gamemode. As a player kills another player, their killstreak increases. Every set interval of kills, a message is broadcasted to all FFA players. Both the message and the interval are configurable through the config. Depending on whether a player is in combat or not, they can teleport to safezone, by typing /spawn.