### PR TITLE
New Feature: Player-Controlled Lobby Music

### DIFF
--- a/src/main/java/dev/revere/alley/api/command/annotation/CommandData.java
+++ b/src/main/java/dev/revere/alley/api/command/annotation/CommandData.java
@@ -29,4 +29,6 @@ public @interface CommandData {
     boolean inGameOnly() default true;
 
     boolean isAdminOnly() default false;
+
+    int cooldown() default 0;
 }

--- a/src/main/java/dev/revere/alley/base/arena/ArenaService.java
+++ b/src/main/java/dev/revere/alley/base/arena/ArenaService.java
@@ -16,10 +16,7 @@ import dev.revere.alley.tool.serializer.Serializer;
 import dev.revere.alley.util.FileUtil;
 import dev.revere.alley.util.VoidChunkGeneratorImpl;
 import lombok.Getter;
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.World;
-import org.bukkit.WorldCreator;
+import org.bukkit.*;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 

--- a/src/main/java/dev/revere/alley/base/queue/QueueProfile.java
+++ b/src/main/java/dev/revere/alley/base/queue/QueueProfile.java
@@ -3,6 +3,7 @@ package dev.revere.alley.base.queue;
 import dev.revere.alley.Alley;
 import dev.revere.alley.tool.reflection.IReflectionRepository;
 import dev.revere.alley.tool.reflection.impl.ActionBarReflectionService;
+import dev.revere.alley.util.TimeUtil;
 import dev.revere.alley.util.chat.CC;
 import dev.revere.alley.util.chat.Symbol;
 import lombok.Data;
@@ -50,7 +51,7 @@ public class QueueProfile {
         this.ticks++;
 
         if (player != null) {
-            String message = "&6" + this.queue.getQueueType() + " " + this.queue.getKit().getDisplayName() + " &7┃ &f" + this.getFormattedElapsedTime();
+            String message = "&6" + this.queue.getQueueType() + " " + this.queue.getKit().getDisplayName() + " &7┃ &f" + TimeUtil.getFormattedElapsedTime(getElapsedTime());
             IReflectionRepository reflectionRepository = Alley.getInstance().getService(IReflectionRepository.class);
             reflectionRepository.getReflectionService(ActionBarReflectionService.class).sendMessage(player, message);
         }
@@ -120,15 +121,5 @@ public class QueueProfile {
      */
     public long getElapsedTime() {
         return System.currentTimeMillis() - this.startTime;
-    }
-
-    /**
-     * Method to get the formatted elapsed time.
-     *
-     * @return The formatted elapsed time.
-     */
-    public String getFormattedElapsedTime() {
-        long elapsedSeconds = getElapsedTime() / 1000;
-        return String.format("%02d:%02d", elapsedSeconds / 60, elapsedSeconds % 60);
     }
 }

--- a/src/main/java/dev/revere/alley/command/impl/other/MusicCommand.java
+++ b/src/main/java/dev/revere/alley/command/impl/other/MusicCommand.java
@@ -1,0 +1,22 @@
+package dev.revere.alley.command.impl.other;
+
+import dev.revere.alley.api.command.BaseCommand;
+import dev.revere.alley.api.command.CommandArgs;
+import dev.revere.alley.api.command.annotation.CommandData;
+import org.bukkit.Effect;
+import org.bukkit.entity.Player;
+
+/**
+ * @author Remi
+ * @project alley-practice
+ * @date 18/07/2025
+ */
+public class MusicCommand extends BaseCommand {
+    @CommandData(name = "music", aliases = "playmusic", isAdminOnly = true)
+    @Override
+    public void onCommand(CommandArgs command) {
+        Player player = command.getPlayer();
+
+        player.playEffect(player.getLocation(), Effect.RECORD_PLAY, 2257);
+    }
+}

--- a/src/main/java/dev/revere/alley/config/locale/impl/ProfileLocale.java
+++ b/src/main/java/dev/revere/alley/config/locale/impl/ProfileLocale.java
@@ -15,9 +15,10 @@ public enum ProfileLocale implements ILocale {
     TOGGLED_PARTY_MESSAGES("messages.yml", "player-settings.party-messages"),
     TOGGLED_SCOREBOARD("messages.yml", "player-settings.scoreboard"),
     TOGGLED_SCOREBOARD_LINES("messages.yml", "player-settings.scoreboard-lines"),
-    TOGGLE_TABLIST("messages.yml", "player-settings.tablist"),
+    TOGGLED_TABLIST("messages.yml", "player-settings.tablist"),
     TOGGLED_PROFANITY_FILTER("messages.yml", "player-settings.profanity-filter"),
-    TOGGLE_DUEL_REQUESTS("messages.yml", "player-settings.duel-requests"),
+    TOGGLED_DUEL_REQUESTS("messages.yml", "player-settings.duel-requests"),
+    TOGGLED_LOBBY_MUSIC("messages.yml", "player-settings.lobby-music"),
 
     IS_BUSY("messages.yml", "error-messages.player.is-busy"),
 

--- a/src/main/java/dev/revere/alley/database/util/MongoUtility.java
+++ b/src/main/java/dev/revere/alley/database/util/MongoUtility.java
@@ -5,6 +5,7 @@ import dev.revere.alley.feature.division.Division;
 import dev.revere.alley.feature.division.IDivisionService;
 import dev.revere.alley.feature.division.tier.DivisionTier;
 import dev.revere.alley.feature.layout.data.LayoutData;
+import dev.revere.alley.feature.music.IMusicService;
 import dev.revere.alley.profile.Profile;
 import dev.revere.alley.profile.data.ProfileData;
 import dev.revere.alley.profile.data.impl.*;
@@ -60,6 +61,7 @@ public class MongoUtility {
         profileDataDocument.put("settingData", convertProfileSettingData(profileData.getSettingData()));
         profileDataDocument.put("cosmeticData", convertProfileCosmeticData(profileData.getCosmeticData()));
         profileDataDocument.put("playTimeData", convertProfilePlayTimeData(profileData.getPlayTimeData()));
+        profileDataDocument.put("musicData", convertProfileMusicData(profileData.getMusicData()));
 
         document.put("profileData", profileDataDocument);
         return document;
@@ -159,6 +161,7 @@ public class MongoUtility {
         settingDocument.put("showScoreboardLines", settingData.isShowScoreboardLines());
         settingDocument.put("profanityFilterEnabled", settingData.isProfanityFilterEnabled());
         settingDocument.put("receiveDuelRequestsEnabled", settingData.isReceiveDuelRequestsEnabled());
+        settingDocument.put("lobbyMusicEnabled", settingData.isLobbyMusicEnabled());
         settingDocument.put("chatChannel", settingData.getChatChannel());
         settingDocument.put("time", settingData.getTime());
         return settingDocument;
@@ -190,6 +193,18 @@ public class MongoUtility {
         playTimeDocument.put("total", playTimeData.getTotal());
         playTimeDocument.put("lastLogin", playTimeData.getLastLogin());
         return playTimeDocument;
+    }
+
+    /**
+     * Converts a ProfileMusicData object to a Document.
+     *
+     * @param musicData The music data to convert.
+     * @return The converted Document.
+     */
+    private Document convertProfileMusicData(ProfileMusicData musicData) {
+        Document musicDocument = new Document();
+        musicDocument.put("selectedDiscs", new ArrayList<>(musicData.getSelectedDiscs()));
+        return musicDocument;
     }
 
     /**
@@ -241,6 +256,8 @@ public class MongoUtility {
             profileData.setSettingData(parseProfileSettingData((Document) profileDataDocument.get("settingData")));
             profileData.setCosmeticData(parseProfileCosmeticData((Document) profileDataDocument.get("cosmeticData")));
             profileData.setPlayTimeData(parseProfilePlayTimeData((Document) profileDataDocument.get("playTimeData")));
+
+            profileData.setMusicData(parseProfileMusicData((Document) profileDataDocument.get("musicData")));
 
             profile.setProfileData(profileData);
         }
@@ -341,6 +358,27 @@ public class MongoUtility {
     }
 
     /**
+     * Parses a ProfileMusicData object from a Document.
+     *
+     * @param musicDocument The music document to parse.
+     * @return The parsed ProfileMusicData.
+     */
+    private ProfileMusicData parseProfileMusicData(Document musicDocument) {
+        ProfileMusicData musicData = new ProfileMusicData();
+
+        if (musicDocument == null) {
+            IMusicService musicService = Alley.getInstance().getService(IMusicService.class);
+            musicService.getMusicDiscs().forEach(disc -> musicData.addDisc(disc.name()));
+            return musicData;
+        }
+
+        List<String> selectedDiscs = musicDocument.getList("selectedDiscs", String.class);
+        musicData.getSelectedDiscs().addAll(selectedDiscs);
+
+        return musicData;
+    }
+
+    /**
      * Parses a ProfileSettingData object from a Document.
      *
      * @param settingDocument The setting document to parse.
@@ -355,6 +393,7 @@ public class MongoUtility {
         settingData.setShowScoreboardLines(settingDocument.getBoolean("showScoreboardLines", true));
         settingData.setProfanityFilterEnabled(settingDocument.getBoolean("profanityFilterEnabled", true));
         settingData.setReceiveDuelRequestsEnabled(settingDocument.getBoolean("receiveDuelRequestsEnabled", true));
+        settingData.setLobbyMusicEnabled(settingDocument.getBoolean("lobbyMusicEnabled", true));
         settingData.setChatChannel(settingDocument.get("chatChannel", EnumChatChannel.GLOBAL.toString()));
         settingData.setTime(settingDocument.get("time", EnumWorldTime.DEFAULT.getName()));
         return settingData;

--- a/src/main/java/dev/revere/alley/feature/music/IMusicService.java
+++ b/src/main/java/dev/revere/alley/feature/music/IMusicService.java
@@ -6,7 +6,9 @@ import dev.revere.alley.profile.Profile;
 import org.bukkit.entity.Player;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * @author Emmy
@@ -15,33 +17,62 @@ import java.util.Set;
  */
 public interface IMusicService extends IService {
     /**
-     * Retrieves a list of all available music discs.
+     * Starts a music session for a player.
+     * This will first stop any currently playing music for the player. A random song
+     * from the player's selected preferences will then be played if their lobby music setting is enabled.
+     * The audio is played client-side and appears to emanate from the spawn location.
      *
-     * @return A list of EnumMusicDisc representing all available music discs.
+     * @param player The player to start the music for.
+     */
+    void startMusic(Player player);
+
+    /**
+     * Fully stops a player's music session.
+     * This is a "hard stop" that halts the audio, cancels any associated tracking tasks,
+     * and completely removes the player's session from memory.
+     *
+     * @param player The player whose music session should be stopped.
+     */
+    void stopMusic(Player player);
+
+    /**
+     * Retrieves a list of all available music discs defined in the system.
+     *
+     * @return An immutable list of {@link EnumMusicDisc} representing all available music discs.
      */
     List<EnumMusicDisc> getMusicDiscs();
 
     /**
-     * Returns a random music disc from the EnumMusicDisc enum.
+     * Selects a random music disc from the entire pool of available discs.
      *
-     * @return A random EnumMusicDisc value.
+     * @return A random {@link EnumMusicDisc} value.
      */
     EnumMusicDisc getRandomMusicDisc();
 
     /**
-     * Retrieves the set of music discs currently selected by the player.
+     * Retrieves the set of music discs a player has selected in their profile.
+     * This method safely converts disc names stored in the profile to {@link EnumMusicDisc} objects.
      *
-     * @param profile The player's profile.
-     * @return A set of EnumMusicDisc values representing the selected discs.
+     * @param profile The player's profile containing their music preferences.
+     * @return A non-null set of {@link EnumMusicDisc} values representing the selected discs.
      */
     Set<EnumMusicDisc> getSelectedMusicDiscs(Profile profile);
 
     /**
-     * Returns a random music disc from the player's *selected* music discs.
-     * If no discs are selected, or if the selection is empty, it might return null or a default disc.
+     * Selects a random music disc from a player's personal list of selected discs.
+     * If the player has not selected any discs, this will fall back to selecting a
+     * random disc from the global pool.
      *
      * @param profile The player's profile.
-     * @return A random EnumMusicDisc from the player's selection, or null if no discs are selected.
+     * @return A random {@link EnumMusicDisc} from the player's selection.
      */
     EnumMusicDisc getRandomSelectedMusicDisc(Profile profile);
+
+    /**
+     * Retrieves the current music session state for a specific player.
+     *
+     * @param playerUuid The UUID of the player.
+     * @return An {@link Optional} containing the {@link MusicSession} if one is active for the player, otherwise empty.
+     */
+    Optional<MusicSession> getMusicState(UUID playerUuid);
 }

--- a/src/main/java/dev/revere/alley/feature/music/IMusicService.java
+++ b/src/main/java/dev/revere/alley/feature/music/IMusicService.java
@@ -1,0 +1,47 @@
+package dev.revere.alley.feature.music;
+
+import dev.revere.alley.feature.music.enums.EnumMusicDisc;
+import dev.revere.alley.plugin.lifecycle.IService;
+import dev.revere.alley.profile.Profile;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Emmy
+ * @project alley-practice
+ * @since 19/07/2025
+ */
+public interface IMusicService extends IService {
+    /**
+     * Retrieves a list of all available music discs.
+     *
+     * @return A list of EnumMusicDisc representing all available music discs.
+     */
+    List<EnumMusicDisc> getMusicDiscs();
+
+    /**
+     * Returns a random music disc from the EnumMusicDisc enum.
+     *
+     * @return A random EnumMusicDisc value.
+     */
+    EnumMusicDisc getRandomMusicDisc();
+
+    /**
+     * Retrieves the set of music discs currently selected by the player.
+     *
+     * @param profile The player's profile.
+     * @return A set of EnumMusicDisc values representing the selected discs.
+     */
+    Set<EnumMusicDisc> getSelectedMusicDiscs(Profile profile);
+
+    /**
+     * Returns a random music disc from the player's *selected* music discs.
+     * If no discs are selected, or if the selection is empty, it might return null or a default disc.
+     *
+     * @param profile The player's profile.
+     * @return A random EnumMusicDisc from the player's selection, or null if no discs are selected.
+     */
+    EnumMusicDisc getRandomSelectedMusicDisc(Profile profile);
+}

--- a/src/main/java/dev/revere/alley/feature/music/MusicService.java
+++ b/src/main/java/dev/revere/alley/feature/music/MusicService.java
@@ -1,76 +1,148 @@
 package dev.revere.alley.feature.music;
 
+import dev.revere.alley.Alley;
+import dev.revere.alley.base.spawn.ISpawnService;
 import dev.revere.alley.feature.music.enums.EnumMusicDisc;
 import dev.revere.alley.plugin.AlleyContext;
 import dev.revere.alley.plugin.annotation.Service;
 import dev.revere.alley.profile.IProfileService;
 import dev.revere.alley.profile.Profile;
 import dev.revere.alley.tool.logger.Logger;
-import lombok.Getter;
+import dev.revere.alley.util.TimeUtil;
+import dev.revere.alley.util.chat.CC;
+import net.minecraft.server.v1_8_R3.BlockPosition;
+import net.minecraft.server.v1_8_R3.PacketPlayOutWorldEvent;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
+import org.bukkit.entity.Player;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 /**
- * @author Emmy
+ * @author Emmy & Remi
  * @project alley-practice
  * @since 19/07/2025
  */
-@Getter
 @Service(provides = IMusicService.class, priority = 175)
 public class MusicService implements IMusicService {
-    private final IProfileService profileService;
+    private static final int RECORD_PLAY_EFFECT_ID = 1005;
 
-    private List<EnumMusicDisc> musicDiscs = new ArrayList<>();
+    private final IProfileService profileService;
+    private final ISpawnService spawnService;
+    private final Map<UUID, MusicSession> activeSessions = new ConcurrentHashMap<>();
     private final ThreadLocalRandom random = ThreadLocalRandom.current();
+
+    private EnumMusicDisc[] allDiscs;
 
     /**
      * DI Constructor for the MusicService class.
      *
      * @param profileService The profile service to be used by this music service.
+     * @param spawnService   The spawn service to be used by this music service.
      */
-    public MusicService(IProfileService profileService) {
+    public MusicService(IProfileService profileService, ISpawnService spawnService) {
         this.profileService = profileService;
+        this.spawnService = spawnService;
     }
 
     @Override
     public void initialize(AlleyContext context) {
-        this.musicDiscs = Arrays.asList(EnumMusicDisc.values());
+        this.allDiscs = EnumMusicDisc.values();
     }
 
-    /**
-     * Returns a random music disc from the EnumMusicDisc enum.
-     *
-     * @return A random EnumMusicDisc value.
-     */
+    @Override
+    public void startMusic(Player player) {
+        stopMusic(player);
+
+        Profile profile = this.profileService.getProfile(player.getUniqueId());
+        if (profile == null || !profile.getProfileData().getSettingData().isLobbyMusicEnabled()) {
+            return;
+        }
+
+        EnumMusicDisc disc = getRandomSelectedMusicDisc(profile);
+        Location jukeboxLocation = spawnService.getLocation();
+        sendPlaySoundPacket(player, disc, jukeboxLocation);
+
+        String formattedDuration = TimeUtil.formatTimeFromSeconds(disc.getDuration());
+        String message = CC.translate("&7[&6♬&7] &fNow playing: &6" + disc.getTitle() + " &7(" + formattedDuration + ")");
+        player.sendMessage(message);
+
+        MusicSession session = new MusicSession(disc, jukeboxLocation);
+        MusicTask task = new MusicTask(player, this, profileService);
+        session.setTask(task.runTaskTimer(Alley.getInstance(), 20L, 20L));
+
+        activeSessions.put(player.getUniqueId(), session);
+    }
+
+    @Override
+    public void stopMusic(Player player) {
+        MusicSession session = activeSessions.remove(player.getUniqueId());
+        if (session != null) {
+            sendStopSoundPacket(player, session.getJukeboxLocation());
+            session.getTask().cancel();
+        }
+    }
+
     @Override
     public EnumMusicDisc getRandomMusicDisc() {
-        EnumMusicDisc[] values = EnumMusicDisc.values();
-        return values[this.random.nextInt(values.length)];
+        if (allDiscs == null || allDiscs.length == 0) {
+            return null;
+        }
+        return allDiscs[random.nextInt(allDiscs.length)];
     }
 
     @Override
     public Set<EnumMusicDisc> getSelectedMusicDiscs(Profile profile) {
-        return profile.getProfileData().getMusicData().getSelectedDiscs().stream().map(name -> {
-            try {
-                return EnumMusicDisc.valueOf(name);
-            } catch (IllegalArgumentException exception) {
-                Logger.logException("Invalid music disc name: " + name, exception);
-                return null;
-            }
-        }).filter(Objects::nonNull).collect(Collectors.toSet());
+        return profile.getProfileData().getMusicData().getSelectedDiscs().stream()
+                .map(name -> {
+                    try {
+                        return EnumMusicDisc.valueOf(name);
+                    } catch (IllegalArgumentException e) {
+                        Logger.logException("Invalid music disc: " + name + " for " + profile.getUuid(), e);
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
     }
 
     @Override
     public EnumMusicDisc getRandomSelectedMusicDisc(Profile profile) {
-        List<EnumMusicDisc> selectedDiscs = new ArrayList<>(this.getSelectedMusicDiscs(profile));
-
-        if (selectedDiscs.isEmpty()) {
-            Logger.error("No music discs selected for profile: " + profile.getUuid());
+        Set<EnumMusicDisc> selectedDiscsSet = this.getSelectedMusicDiscs(profile);
+        if (selectedDiscsSet.isEmpty()) {
             return this.getRandomMusicDisc();
         }
 
+        List<EnumMusicDisc> selectedDiscs = new ArrayList<>(selectedDiscsSet);
         return selectedDiscs.get(this.random.nextInt(selectedDiscs.size()));
+    }
+
+    @Override
+    public Optional<MusicSession> getMusicState(UUID playerUuid) {
+        return Optional.ofNullable(activeSessions.get(playerUuid));
+    }
+
+    @Override
+    public List<EnumMusicDisc> getMusicDiscs() {
+        return Arrays.asList(this.allDiscs);
+    }
+
+    MusicSession getSession(UUID playerUuid) {
+        return activeSessions.get(playerUuid);
+    }
+
+    public void sendPlaySoundPacket(Player player, EnumMusicDisc disc, Location location) {
+        BlockPosition pos = new BlockPosition(location.getX(), location.getY(), location.getZ());
+        PacketPlayOutWorldEvent packet = new PacketPlayOutWorldEvent(RECORD_PLAY_EFFECT_ID, pos, disc.getMaterial().getId(), false);
+        ((CraftPlayer) player).getHandle().playerConnection.sendPacket(packet);
+    }
+
+    public void sendStopSoundPacket(Player player, Location location) {
+        BlockPosition pos = new BlockPosition(location.getX(), location.getY(), location.getZ());
+        PacketPlayOutWorldEvent packet = new PacketPlayOutWorldEvent(RECORD_PLAY_EFFECT_ID, pos, 0, false);
+        ((CraftPlayer) player).getHandle().playerConnection.sendPacket(packet);
     }
 }

--- a/src/main/java/dev/revere/alley/feature/music/MusicService.java
+++ b/src/main/java/dev/revere/alley/feature/music/MusicService.java
@@ -1,0 +1,76 @@
+package dev.revere.alley.feature.music;
+
+import dev.revere.alley.feature.music.enums.EnumMusicDisc;
+import dev.revere.alley.plugin.AlleyContext;
+import dev.revere.alley.plugin.annotation.Service;
+import dev.revere.alley.profile.IProfileService;
+import dev.revere.alley.profile.Profile;
+import dev.revere.alley.tool.logger.Logger;
+import lombok.Getter;
+
+import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+
+/**
+ * @author Emmy
+ * @project alley-practice
+ * @since 19/07/2025
+ */
+@Getter
+@Service(provides = IMusicService.class, priority = 175)
+public class MusicService implements IMusicService {
+    private final IProfileService profileService;
+
+    private List<EnumMusicDisc> musicDiscs = new ArrayList<>();
+    private final ThreadLocalRandom random = ThreadLocalRandom.current();
+
+    /**
+     * DI Constructor for the MusicService class.
+     *
+     * @param profileService The profile service to be used by this music service.
+     */
+    public MusicService(IProfileService profileService) {
+        this.profileService = profileService;
+    }
+
+    @Override
+    public void initialize(AlleyContext context) {
+        this.musicDiscs = Arrays.asList(EnumMusicDisc.values());
+    }
+
+    /**
+     * Returns a random music disc from the EnumMusicDisc enum.
+     *
+     * @return A random EnumMusicDisc value.
+     */
+    @Override
+    public EnumMusicDisc getRandomMusicDisc() {
+        EnumMusicDisc[] values = EnumMusicDisc.values();
+        return values[this.random.nextInt(values.length)];
+    }
+
+    @Override
+    public Set<EnumMusicDisc> getSelectedMusicDiscs(Profile profile) {
+        return profile.getProfileData().getMusicData().getSelectedDiscs().stream().map(name -> {
+            try {
+                return EnumMusicDisc.valueOf(name);
+            } catch (IllegalArgumentException exception) {
+                Logger.logException("Invalid music disc name: " + name, exception);
+                return null;
+            }
+        }).filter(Objects::nonNull).collect(Collectors.toSet());
+    }
+
+    @Override
+    public EnumMusicDisc getRandomSelectedMusicDisc(Profile profile) {
+        List<EnumMusicDisc> selectedDiscs = new ArrayList<>(this.getSelectedMusicDiscs(profile));
+
+        if (selectedDiscs.isEmpty()) {
+            Logger.error("No music discs selected for profile: " + profile.getUuid());
+            return this.getRandomMusicDisc();
+        }
+
+        return selectedDiscs.get(this.random.nextInt(selectedDiscs.size()));
+    }
+}

--- a/src/main/java/dev/revere/alley/feature/music/MusicSession.java
+++ b/src/main/java/dev/revere/alley/feature/music/MusicSession.java
@@ -1,0 +1,34 @@
+package dev.revere.alley.feature.music;
+
+import dev.revere.alley.feature.music.enums.EnumMusicDisc;
+import lombok.Getter;
+import lombok.Setter;
+import org.bukkit.Location;
+import org.bukkit.scheduler.BukkitTask;
+
+/**
+ * @author Remi
+ * @project alley-practice
+ * @date 20/07/2025
+ */
+
+@Getter
+public class MusicSession {
+    private final EnumMusicDisc disc;
+    private final long startTime;
+    private final Location jukeboxLocation;
+
+    @Setter private BukkitTask task;
+    @Setter private int elapsedSeconds = 0;
+    @Setter private boolean paused = false;
+
+    public MusicSession(EnumMusicDisc disc, Location jukeboxLocation) {
+        this.disc = disc;
+        this.startTime = System.currentTimeMillis();
+        this.jukeboxLocation = jukeboxLocation;
+    }
+
+    public boolean isFinished() {
+        return elapsedSeconds >= disc.getDuration();
+    }
+}

--- a/src/main/java/dev/revere/alley/feature/music/MusicTask.java
+++ b/src/main/java/dev/revere/alley/feature/music/MusicTask.java
@@ -1,0 +1,68 @@
+package dev.revere.alley.feature.music;
+
+import dev.revere.alley.profile.IProfileService;
+import dev.revere.alley.profile.Profile;
+import dev.revere.alley.profile.enums.EnumProfileState;
+import lombok.RequiredArgsConstructor;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+
+/**
+ * @author Remi
+ * @project alley-practice
+ * @date 20/07/2025
+ */
+@RequiredArgsConstructor
+public class MusicTask extends BukkitRunnable {
+    private final Player player;
+    private final MusicService musicService;
+    private final IProfileService profileService;
+
+    @Override
+    public void run() {
+        if (!player.isOnline()) {
+            cancel();
+            return;
+        }
+
+        MusicSession session = musicService.getSession(player.getUniqueId());
+        if (session == null || session.getTask().getTaskId() != getTaskId()) {
+            cancel();
+            return;
+        }
+
+        Profile profile = profileService.getProfile(player.getUniqueId());
+        if (profile == null) {
+            musicService.stopMusic(player);
+            return;
+        }
+
+        boolean shouldPlay = shouldPlayMusic(profile);
+
+        if (!shouldPlay && !session.isPaused()) {
+            musicService.sendStopSoundPacket(player, session.getJukeboxLocation());
+            session.setPaused(true);
+            return;
+        }
+
+        if (shouldPlay && session.isPaused()) {
+            musicService.sendPlaySoundPacket(player, session.getDisc(), session.getJukeboxLocation());
+            session.setPaused(false);
+            session.setElapsedSeconds(0);
+        }
+
+        if (shouldPlay && !session.isPaused()) {
+            if (session.isFinished()) {
+                cancel();
+                musicService.startMusic(player);
+            }
+
+            session.setElapsedSeconds(session.getElapsedSeconds() + 1);
+        }
+    }
+
+    private boolean shouldPlayMusic(Profile profile) {
+        boolean inLobby = profile.getState() == EnumProfileState.LOBBY || profile.getState() == EnumProfileState.WAITING;
+        return inLobby && profile.getProfileData().getSettingData().isLobbyMusicEnabled();
+    }
+}

--- a/src/main/java/dev/revere/alley/feature/music/enums/EnumMusicDisc.java
+++ b/src/main/java/dev/revere/alley/feature/music/enums/EnumMusicDisc.java
@@ -1,0 +1,46 @@
+package dev.revere.alley.feature.music.enums;
+
+import lombok.Getter;
+import org.bukkit.Material;
+
+/**
+ * Represents a music disc in the game.
+ * Each music disc has a material type, a title, and a unique ID.
+ * This enum is used to manage and identify different music discs.
+ *
+ * @author Emmy
+ * @project Alley
+ * @date 27/10/2024 - 08:43
+ */
+@Getter
+public enum EnumMusicDisc {
+    GOLD_RECORD(Material.GOLD_RECORD, "13", 2256),
+    GREEN_RECORD(Material.GREEN_RECORD, "Cat", 2257),
+    RECORD_3(Material.RECORD_3, "Blocks", 2258),
+    RECORD_4(Material.RECORD_4, "Chirp", 2259),
+    RECORD_5(Material.RECORD_5, "Far", 2260),
+    RECORD_6(Material.RECORD_6, "Mall", 2261),
+    RECORD_7(Material.RECORD_7, "Mellohi", 2262),
+    RECORD_8(Material.RECORD_8, "Stal", 2263),
+    RECORD_9(Material.RECORD_9, "Strad", 2264),
+    RECORD_10(Material.RECORD_10, "Ward", 2265),
+    RECORD_11(Material.RECORD_11, "11", 2266),
+    RECORD_12(Material.RECORD_12, "Wait", 2267);
+
+    private final Material material;
+    private final String title;
+    private final int id;
+
+    /**
+     * Constructor for the MusicDisc enum.
+     *
+     * @param material The material type of the music disc.
+     * @param title    The title of the music disc.
+     * @param id       The unique ID of the music.
+     */
+    EnumMusicDisc(Material material, String title, int id) {
+        this.material = material;
+        this.title = title;
+        this.id = id;
+    }
+}

--- a/src/main/java/dev/revere/alley/feature/music/enums/EnumMusicDisc.java
+++ b/src/main/java/dev/revere/alley/feature/music/enums/EnumMusicDisc.java
@@ -14,33 +14,28 @@ import org.bukkit.Material;
  */
 @Getter
 public enum EnumMusicDisc {
-    GOLD_RECORD(Material.GOLD_RECORD, "13", 2256),
-    GREEN_RECORD(Material.GREEN_RECORD, "Cat", 2257),
-    RECORD_3(Material.RECORD_3, "Blocks", 2258),
-    RECORD_4(Material.RECORD_4, "Chirp", 2259),
-    RECORD_5(Material.RECORD_5, "Far", 2260),
-    RECORD_6(Material.RECORD_6, "Mall", 2261),
-    RECORD_7(Material.RECORD_7, "Mellohi", 2262),
-    RECORD_8(Material.RECORD_8, "Stal", 2263),
-    RECORD_9(Material.RECORD_9, "Strad", 2264),
-    RECORD_10(Material.RECORD_10, "Ward", 2265),
-    RECORD_11(Material.RECORD_11, "11", 2266),
-    RECORD_12(Material.RECORD_12, "Wait", 2267);
+    GOLD_RECORD(Material.GOLD_RECORD, "13", "records.13", 178),
+    GREEN_RECORD(Material.GREEN_RECORD, "Cat", "records.cat", 185),
+    RECORD_3(Material.RECORD_3, "Blocks", "records.blocks", 345),
+    RECORD_4(Material.RECORD_4, "Chirp", "records.chirp", 185),
+    RECORD_5(Material.RECORD_5, "Far", "records.far", 174),
+    RECORD_6(Material.RECORD_6, "Mall", "records.mall", 197),
+    RECORD_7(Material.RECORD_7, "Mellohi", "records.mellohi", 96),
+    RECORD_8(Material.RECORD_8, "Stal", "records.stal", 150),
+    RECORD_9(Material.RECORD_9, "Strad", "records.strad", 188),
+    RECORD_10(Material.RECORD_10, "Ward", "records.ward", 251),
+    RECORD_11(Material.RECORD_11, "11", "records.11", 71),
+    RECORD_12(Material.RECORD_12, "Wait", "records.wait", 238);
 
     private final Material material;
     private final String title;
-    private final int id;
+    private final String soundName;
+    private final int duration;
 
-    /**
-     * Constructor for the MusicDisc enum.
-     *
-     * @param material The material type of the music disc.
-     * @param title    The title of the music disc.
-     * @param id       The unique ID of the music.
-     */
-    EnumMusicDisc(Material material, String title, int id) {
+    EnumMusicDisc(Material material, String title, String soundName, int duration) {
         this.material = material;
         this.title = title;
-        this.id = id;
+        this.soundName = soundName;
+        this.duration = duration;
     }
 }

--- a/src/main/java/dev/revere/alley/game/match/AbstractMatch.java
+++ b/src/main/java/dev/revere/alley/game/match/AbstractMatch.java
@@ -40,6 +40,7 @@ import dev.revere.alley.tool.reflection.impl.TitleReflectionService;
 import dev.revere.alley.util.ListenerUtil;
 import dev.revere.alley.util.PlayerUtil;
 import dev.revere.alley.util.SoundUtil;
+import dev.revere.alley.util.TimeUtil;
 import dev.revere.alley.util.chat.CC;
 import lombok.Getter;
 import lombok.Setter;
@@ -785,11 +786,11 @@ public abstract class AbstractMatch {
      */
     public String getDuration() {
         if (this.state == EnumMatchState.STARTING) {
-            return this.getFormattedElapsedTime(this.getElapsedTime());
+            return TimeUtil.getFormattedElapsedTime(this.getElapsedTime());
         } else if (this.state == EnumMatchState.ENDING_MATCH) {
-            return this.getFormattedElapsedTime(this.endTime - this.startTime);
+            return TimeUtil.getFormattedElapsedTime(this.endTime - this.startTime);
         } else {
-            return this.getFormattedElapsedTime(this.getElapsedTime());
+            return TimeUtil.getFormattedElapsedTime(this.getElapsedTime());
         }
     }
 
@@ -800,16 +801,6 @@ public abstract class AbstractMatch {
      */
     public long getElapsedTime() {
         return System.currentTimeMillis() - this.startTime;
-    }
-
-    /**
-     * Gets the formatted elapsed time of the match.
-     *
-     * @return The formatted elapsed time of the match.
-     */
-    public String getFormattedElapsedTime(long elapsedMillis) {
-        long elapsedSeconds = elapsedMillis / 1000;
-        return String.format("%02d:%02d", elapsedSeconds / 60, elapsedSeconds % 60);
     }
 
     /**

--- a/src/main/java/dev/revere/alley/profile/command/player/LobbyMusicCommand.java
+++ b/src/main/java/dev/revere/alley/profile/command/player/LobbyMusicCommand.java
@@ -1,0 +1,23 @@
+package dev.revere.alley.profile.command.player;
+
+import dev.revere.alley.api.command.BaseCommand;
+import dev.revere.alley.api.command.CommandArgs;
+import dev.revere.alley.api.command.annotation.CommandData;
+import dev.revere.alley.profile.menu.music.MusicDiscSelectorMenu;
+
+/**
+ * @author Emmy
+ * @project alley-practice
+ * @since 19/07/2025
+ */
+public class LobbyMusicCommand extends BaseCommand {
+    @CommandData(
+            name = "lobbymusic",
+            aliases = {"music"},
+            permission = "alley.donator.command.lobbymusic"
+    )
+    @Override
+    public void onCommand(CommandArgs command) {
+        new MusicDiscSelectorMenu().openMenu(command.getPlayer());
+    }
+}

--- a/src/main/java/dev/revere/alley/profile/command/player/setting/toggle/ToggleDuelRequestsCommand.java
+++ b/src/main/java/dev/revere/alley/profile/command/player/setting/toggle/ToggleDuelRequestsCommand.java
@@ -24,6 +24,6 @@ public class ToggleDuelRequestsCommand extends BaseCommand {
         Profile profile = profileService.getProfile(player.getUniqueId());
         profile.getProfileData().getSettingData().setReceiveDuelRequestsEnabled(!profile.getProfileData().getSettingData().isReceiveDuelRequestsEnabled());
 
-        player.sendMessage(CC.translate(ProfileLocale.TOGGLE_DUEL_REQUESTS.getMessage().replace("{status}", profile.getProfileData().getSettingData().isReceiveDuelRequestsEnabled() ? "&aenabled" : "&cdisabled")));
+        player.sendMessage(CC.translate(ProfileLocale.TOGGLED_DUEL_REQUESTS.getMessage().replace("{status}", profile.getProfileData().getSettingData().isReceiveDuelRequestsEnabled() ? "&aenabled" : "&cdisabled")));
     }
 }

--- a/src/main/java/dev/revere/alley/profile/command/player/setting/toggle/ToggleLobbyMusicCommand.java
+++ b/src/main/java/dev/revere/alley/profile/command/player/setting/toggle/ToggleLobbyMusicCommand.java
@@ -11,20 +11,19 @@ import org.bukkit.entity.Player;
 
 /**
  * @author Emmy
- * @project Alley
- * @date 25/05/2024 - 23:35
+ * @project alley-practice
+ * @since 19/07/2025
  */
-
-public class ToggleTablistCommand extends BaseCommand {
+public class ToggleLobbyMusicCommand extends BaseCommand {
+    @CommandData(name = "togglelobbymusic")
     @Override
-    @CommandData(name = "toggletablist")
     public void onCommand(CommandArgs command) {
         Player player = command.getPlayer();
 
         IProfileService profileService = this.plugin.getService(IProfileService.class);
         Profile profile = profileService.getProfile(player.getUniqueId());
-        profile.getProfileData().getSettingData().setTablistEnabled(!profile.getProfileData().getSettingData().isTablistEnabled());
+        profile.getProfileData().getSettingData().setLobbyMusicEnabled(!profile.getProfileData().getSettingData().isLobbyMusicEnabled());
 
-        player.sendMessage(CC.translate(ProfileLocale.TOGGLED_TABLIST.getMessage().replace("{status}", profile.getProfileData().getSettingData().isTablistEnabled() ? "&aenabled" : "&cdisabled")));
+        player.sendMessage(CC.translate(ProfileLocale.TOGGLED_LOBBY_MUSIC.getMessage().replace("{status}", profile.getProfileData().getSettingData().isLobbyMusicEnabled() ? "&aenabled" : "&cdisabled")));
     }
 }

--- a/src/main/java/dev/revere/alley/profile/command/player/setting/toggle/ToggleLobbyMusicCommand.java
+++ b/src/main/java/dev/revere/alley/profile/command/player/setting/toggle/ToggleLobbyMusicCommand.java
@@ -4,6 +4,7 @@ import dev.revere.alley.api.command.BaseCommand;
 import dev.revere.alley.api.command.CommandArgs;
 import dev.revere.alley.api.command.annotation.CommandData;
 import dev.revere.alley.config.locale.impl.ProfileLocale;
+import dev.revere.alley.feature.music.IMusicService;
 import dev.revere.alley.profile.IProfileService;
 import dev.revere.alley.profile.Profile;
 import dev.revere.alley.util.chat.CC;
@@ -15,14 +16,23 @@ import org.bukkit.entity.Player;
  * @since 19/07/2025
  */
 public class ToggleLobbyMusicCommand extends BaseCommand {
-    @CommandData(name = "togglelobbymusic")
+    @CommandData(name = "togglelobbymusic", cooldown = 1)
     @Override
     public void onCommand(CommandArgs command) {
         Player player = command.getPlayer();
 
         IProfileService profileService = this.plugin.getService(IProfileService.class);
+        IMusicService musicService = this.plugin.getService(IMusicService.class);
+
         Profile profile = profileService.getProfile(player.getUniqueId());
         profile.getProfileData().getSettingData().setLobbyMusicEnabled(!profile.getProfileData().getSettingData().isLobbyMusicEnabled());
+
+        boolean isEnabled = profile.getProfileData().getSettingData().isLobbyMusicEnabled();
+        if (isEnabled) {
+            musicService.startMusic(player);
+        } else {
+            musicService.stopMusic(player);
+        }
 
         player.sendMessage(CC.translate(ProfileLocale.TOGGLED_LOBBY_MUSIC.getMessage().replace("{status}", profile.getProfileData().getSettingData().isLobbyMusicEnabled() ? "&aenabled" : "&cdisabled")));
     }

--- a/src/main/java/dev/revere/alley/profile/data/ProfileData.java
+++ b/src/main/java/dev/revere/alley/profile/data/ProfileData.java
@@ -6,6 +6,7 @@ import dev.revere.alley.base.kit.IKitService;
 import dev.revere.alley.base.kit.Kit;
 import dev.revere.alley.base.kit.setting.impl.mode.KitSettingRankedImpl;
 import dev.revere.alley.feature.level.ILevelService;
+import dev.revere.alley.feature.music.IMusicService;
 import dev.revere.alley.feature.title.ITitleService;
 import dev.revere.alley.feature.title.record.TitleRecord;
 import dev.revere.alley.game.match.data.AbstractMatchData;
@@ -38,6 +39,7 @@ public class ProfileData {
     private ProfileSettingData settingData;
     private ProfileCosmeticData cosmeticData;
     private ProfilePlayTimeData playTimeData;
+    private ProfileMusicData musicData;
 
     private List<AbstractMatchData> previousMatches;
 
@@ -68,6 +70,7 @@ public class ProfileData {
         this.cosmeticData = new ProfileCosmeticData();
         this.playTimeData = new ProfilePlayTimeData();
         this.layoutData = new ProfileLayoutData();
+        this.musicData = new ProfileMusicData();
     }
 
     private void feedDataClasses() {

--- a/src/main/java/dev/revere/alley/profile/data/impl/ProfileMusicData.java
+++ b/src/main/java/dev/revere/alley/profile/data/impl/ProfileMusicData.java
@@ -17,14 +17,10 @@ import java.util.Set;
 @Getter
 @Setter
 public class ProfileMusicData {
-    private final Set<String> selectedDiscs;
-    private boolean isPlaying = false;
+    private Set<String> selectedDiscs;
 
-    public ProfileMusicData () {
+    public ProfileMusicData() {
         this.selectedDiscs = new HashSet<>();
-
-        IMusicService musicService = Alley.getInstance().getService(IMusicService.class);
-        musicService.getMusicDiscs().forEach(disc -> this.addDisc(disc.name()));
     }
 
     /**

--- a/src/main/java/dev/revere/alley/profile/data/impl/ProfileMusicData.java
+++ b/src/main/java/dev/revere/alley/profile/data/impl/ProfileMusicData.java
@@ -1,0 +1,57 @@
+package dev.revere.alley.profile.data.impl;
+
+import dev.revere.alley.Alley;
+import dev.revere.alley.feature.music.IMusicService;
+import lombok.Getter;
+import lombok.Setter;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author Emmy
+ * @project alley-practice
+ * @since 19/07/2025
+ */
+@Getter
+@Setter
+public class ProfileMusicData {
+    private final Set<String> selectedDiscs;
+    private boolean isPlaying = false;
+
+    public ProfileMusicData () {
+        this.selectedDiscs = new HashSet<>();
+
+        IMusicService musicService = Alley.getInstance().getService(IMusicService.class);
+        musicService.getMusicDiscs().forEach(disc -> this.addDisc(disc.name()));
+    }
+
+    /**
+     * Adds a music disc to the selected discs set.
+     *
+     * @param disc The name of the music disc to add.
+     */
+    public void addDisc(String disc) {
+        this.selectedDiscs.add(disc);
+    }
+
+    /**
+     * Removes a music disc from the selected discs set.
+     *
+     * @param disc The name of the music disc to remove.
+     */
+    public void removeDisc(String disc) {
+        this.selectedDiscs.remove(disc);
+    }
+
+    /**
+     * Checks if a music disc is selected.
+     *
+     * @param disc The name of the music disc to check.
+     * @return True if the disc is selected, false otherwise.
+     */
+    public boolean isDiscSelected(String disc) {
+        return this.selectedDiscs.contains(disc);
+    }
+}

--- a/src/main/java/dev/revere/alley/profile/data/impl/ProfileSettingData.java
+++ b/src/main/java/dev/revere/alley/profile/data/impl/ProfileSettingData.java
@@ -21,6 +21,7 @@ public class ProfileSettingData {
     private boolean showScoreboardLines;
     private boolean isProfanityFilterEnabled;
     private boolean receiveDuelRequestsEnabled;
+    private boolean lobbyMusicEnabled;
     private String chatChannel;
     private String time;
 
@@ -35,6 +36,7 @@ public class ProfileSettingData {
         this.showScoreboardLines = true;
         this.isProfanityFilterEnabled = false;
         this.receiveDuelRequestsEnabled = true;
+        this.lobbyMusicEnabled = true;
         this.chatChannel = EnumChatChannel.GLOBAL.toString();
         this.time = EnumWorldTime.DEFAULT.getName();
     }

--- a/src/main/java/dev/revere/alley/profile/listener/ProfileListener.java
+++ b/src/main/java/dev/revere/alley/profile/listener/ProfileListener.java
@@ -6,6 +6,7 @@ import dev.revere.alley.base.hotbar.IHotbarService;
 import dev.revere.alley.base.spawn.ISpawnService;
 import dev.revere.alley.base.visibility.IVisibilityService;
 import dev.revere.alley.config.IConfigService;
+import dev.revere.alley.feature.music.IMusicService;
 import dev.revere.alley.profile.IProfileService;
 import dev.revere.alley.profile.Profile;
 import dev.revere.alley.profile.enums.EnumProfileState;
@@ -89,9 +90,13 @@ public class ProfileListener implements Listener {
     private void onPlayerQuitEvent(PlayerQuitEvent event) {
         Player player = event.getPlayer();
         IProfileService profileService = Alley.getInstance().getService(IProfileService.class);
+        IMusicService musicService = Alley.getInstance().getService(IMusicService.class);
+
         Profile profile = profileService.getProfile(player.getUniqueId());
 
         event.setQuitMessage(null);
+
+        musicService.stopMusic(player);
 
         profile.updatePlayTime();
         profile.setOnline(false);
@@ -134,6 +139,7 @@ public class ProfileListener implements Listener {
         ISpawnService spawnService = Alley.getInstance().getService(ISpawnService.class);
         IHotbarService hotbarService = Alley.getInstance().getService(IHotbarService.class);
         IVisibilityService visibilityService = Alley.getInstance().getService(IVisibilityService.class);
+        IMusicService musicService = Alley.getInstance().getService(IMusicService.class);
 
         profile.setState(EnumProfileState.LOBBY);
         profile.setName(player.getName());
@@ -156,6 +162,7 @@ public class ProfileListener implements Listener {
         spawnService.teleportToSpawn(player);
         hotbarService.applyHotbarItems(player);
         visibilityService.updateVisibility(player);
+        musicService.startMusic(player);
 
         player.updateInventory();
     }

--- a/src/main/java/dev/revere/alley/profile/menu/music/MusicDiscSelectorMenu.java
+++ b/src/main/java/dev/revere/alley/profile/menu/music/MusicDiscSelectorMenu.java
@@ -25,7 +25,7 @@ import java.util.Map;
 public class MusicDiscSelectorMenu extends Menu {
     @Override
     public String getTitle(Player player) {
-        return "&6&lMusic Discs";
+        return "&6&lSongs";
     }
 
     @Override

--- a/src/main/java/dev/revere/alley/profile/menu/music/MusicDiscSelectorMenu.java
+++ b/src/main/java/dev/revere/alley/profile/menu/music/MusicDiscSelectorMenu.java
@@ -1,0 +1,53 @@
+package dev.revere.alley.profile.menu.music;
+
+import dev.revere.alley.Alley;
+import dev.revere.alley.api.menu.Button;
+import dev.revere.alley.api.menu.Menu;
+import dev.revere.alley.feature.music.IMusicService;
+import dev.revere.alley.feature.music.enums.EnumMusicDisc;
+import dev.revere.alley.profile.IProfileService;
+import dev.revere.alley.profile.Profile;
+import dev.revere.alley.profile.menu.music.button.MusicDiscSelectorButton;
+import org.bukkit.entity.Player;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Emmy
+ * @project alley-practice
+ * @since 19/07/2025
+ */
+public class MusicDiscSelectorMenu extends Menu {
+    @Override
+    public String getTitle(Player player) {
+        return "&6&lMusic Discs";
+    }
+
+    @Override
+    public Map<Integer, Button> getButtons(Player player) {
+        Map<Integer, Button> buttons = new HashMap<>();
+
+        Profile profile = Alley.getInstance().getService(IProfileService.class).getProfile(player.getUniqueId());
+
+        IMusicService musicService = Alley.getInstance().getService(IMusicService.class);
+        List<EnumMusicDisc> musicDiscs = musicService.getMusicDiscs();
+
+        int slot = 10;
+        for (EnumMusicDisc disc : musicDiscs) {
+            slot = this.skipIfSlotCrossingBorder(slot);
+            buttons.put(slot, new MusicDiscSelectorButton(profile, disc));
+            slot++;
+        }
+
+        this.addBorder(buttons, (short)15, 4);
+
+        return buttons;
+    }
+
+    @Override
+    public int getSize() {
+        return 9 * 4;
+    }
+}

--- a/src/main/java/dev/revere/alley/profile/menu/music/MusicDiscSelectorMenu.java
+++ b/src/main/java/dev/revere/alley/profile/menu/music/MusicDiscSelectorMenu.java
@@ -3,11 +3,14 @@ package dev.revere.alley.profile.menu.music;
 import dev.revere.alley.Alley;
 import dev.revere.alley.api.menu.Button;
 import dev.revere.alley.api.menu.Menu;
+import dev.revere.alley.api.menu.impl.BackButton;
 import dev.revere.alley.feature.music.IMusicService;
 import dev.revere.alley.feature.music.enums.EnumMusicDisc;
 import dev.revere.alley.profile.IProfileService;
 import dev.revere.alley.profile.Profile;
 import dev.revere.alley.profile.menu.music.button.MusicDiscSelectorButton;
+import dev.revere.alley.profile.menu.music.button.ToggleLobbyMusicButton;
+import dev.revere.alley.profile.menu.setting.PracticeSettingsMenu;
 import org.bukkit.entity.Player;
 
 import java.util.HashMap;
@@ -41,7 +44,10 @@ public class MusicDiscSelectorMenu extends Menu {
             slot++;
         }
 
-        this.addBorder(buttons, (short)15, 4);
+        this.addBorder(buttons, (short) 15, 4);
+
+        buttons.put(4, new ToggleLobbyMusicButton());
+        buttons.put(0, new BackButton(new PracticeSettingsMenu()));
 
         return buttons;
     }

--- a/src/main/java/dev/revere/alley/profile/menu/music/button/MusicDiscSelectorButton.java
+++ b/src/main/java/dev/revere/alley/profile/menu/music/button/MusicDiscSelectorButton.java
@@ -5,7 +5,6 @@ import dev.revere.alley.feature.music.enums.EnumMusicDisc;
 import dev.revere.alley.profile.Profile;
 import dev.revere.alley.profile.data.impl.ProfileMusicData;
 import dev.revere.alley.tool.item.ItemBuilder;
-import dev.revere.alley.tool.visual.LoreHelper;
 import dev.revere.alley.util.chat.CC;
 import lombok.AllArgsConstructor;
 import org.bukkit.entity.Player;
@@ -28,8 +27,6 @@ public class MusicDiscSelectorButton extends Button {
                 .name("&6&l" + this.disc.getTitle())
                 .lore(
                         "",
-                        LoreHelper.toggledOrNot(this.profile.getProfileData().getMusicData().isDiscSelected(this.disc.name())),
-                        "",
                         "&aClick to change!"
                 )
                 .build();
@@ -40,6 +37,12 @@ public class MusicDiscSelectorButton extends Button {
         if (clickType != ClickType.LEFT) return;
 
         ProfileMusicData musicData = this.profile.getProfileData().getMusicData();
+
+        if (musicData.getSelectedDiscs().isEmpty()) {
+            player.sendMessage(CC.translate("&cYou must at least select one music disc before you can toggle them!"));
+            return;
+        }
+
         if (musicData.isDiscSelected(this.disc.name())) {
             musicData.removeDisc(this.disc.name());
             player.sendMessage(CC.translate("&cYou have removed &6" + this.disc.getTitle() + "&c from your music selection."));
@@ -47,5 +50,7 @@ public class MusicDiscSelectorButton extends Button {
             musicData.addDisc(this.disc.name());
             player.sendMessage(CC.translate("&aYou have added &6" + this.disc.getTitle() + "&a to your music selection."));
         }
+
+        this.playNeutral(player);
     }
 }

--- a/src/main/java/dev/revere/alley/profile/menu/music/button/MusicDiscSelectorButton.java
+++ b/src/main/java/dev/revere/alley/profile/menu/music/button/MusicDiscSelectorButton.java
@@ -5,6 +5,7 @@ import dev.revere.alley.feature.music.enums.EnumMusicDisc;
 import dev.revere.alley.profile.Profile;
 import dev.revere.alley.profile.data.impl.ProfileMusicData;
 import dev.revere.alley.tool.item.ItemBuilder;
+import dev.revere.alley.tool.visual.LoreHelper;
 import dev.revere.alley.util.chat.CC;
 import lombok.AllArgsConstructor;
 import org.bukkit.entity.Player;
@@ -26,6 +27,8 @@ public class MusicDiscSelectorButton extends Button {
         return new ItemBuilder(this.disc.getMaterial())
                 .name("&6&l" + this.disc.getTitle())
                 .lore(
+                        "",
+                        LoreHelper.toggledOrNot(this.profile.getProfileData().getMusicData().isDiscSelected(this.disc.name())),
                         "",
                         "&aClick to change!"
                 )

--- a/src/main/java/dev/revere/alley/profile/menu/music/button/MusicDiscSelectorButton.java
+++ b/src/main/java/dev/revere/alley/profile/menu/music/button/MusicDiscSelectorButton.java
@@ -1,0 +1,51 @@
+package dev.revere.alley.profile.menu.music.button;
+
+import dev.revere.alley.api.menu.Button;
+import dev.revere.alley.feature.music.enums.EnumMusicDisc;
+import dev.revere.alley.profile.Profile;
+import dev.revere.alley.profile.data.impl.ProfileMusicData;
+import dev.revere.alley.tool.item.ItemBuilder;
+import dev.revere.alley.tool.visual.LoreHelper;
+import dev.revere.alley.util.chat.CC;
+import lombok.AllArgsConstructor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * @author Emmy
+ * @project alley-practice
+ * @since 19/07/2025
+ */
+@AllArgsConstructor
+public class MusicDiscSelectorButton extends Button {
+    private final Profile profile;
+    private final EnumMusicDisc disc;
+
+    @Override
+    public ItemStack getButtonItem(Player player) {
+        return new ItemBuilder(this.disc.getMaterial())
+                .name("&6&l" + this.disc.getTitle())
+                .lore(
+                        "",
+                        LoreHelper.toggledOrNot(this.profile.getProfileData().getMusicData().isDiscSelected(this.disc.name())),
+                        "",
+                        "&aClick to change!"
+                )
+                .build();
+    }
+
+    @Override
+    public void clicked(Player player, ClickType clickType) {
+        if (clickType != ClickType.LEFT) return;
+
+        ProfileMusicData musicData = this.profile.getProfileData().getMusicData();
+        if (musicData.isDiscSelected(this.disc.name())) {
+            musicData.removeDisc(this.disc.name());
+            player.sendMessage(CC.translate("&cYou have removed &6" + this.disc.getTitle() + "&c from your music selection."));
+        } else {
+            musicData.addDisc(this.disc.name());
+            player.sendMessage(CC.translate("&aYou have added &6" + this.disc.getTitle() + "&a to your music selection."));
+        }
+    }
+}

--- a/src/main/java/dev/revere/alley/profile/menu/music/button/ToggleLobbyMusicButton.java
+++ b/src/main/java/dev/revere/alley/profile/menu/music/button/ToggleLobbyMusicButton.java
@@ -1,0 +1,43 @@
+package dev.revere.alley.profile.menu.music.button;
+
+import dev.revere.alley.Alley;
+import dev.revere.alley.api.menu.Button;
+import dev.revere.alley.profile.IProfileService;
+import dev.revere.alley.profile.Profile;
+import dev.revere.alley.tool.item.ItemBuilder;
+import dev.revere.alley.tool.visual.LoreHelper;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * @author Emmy
+ * @project alley-practice
+ * @since 20/07/2025
+ */
+public class ToggleLobbyMusicButton extends Button {
+    @Override
+    public ItemStack getButtonItem(Player player) {
+        Profile profile = Alley.getInstance().getService(IProfileService.class).getProfile(player.getUniqueId());
+        return new ItemBuilder(Material.EMERALD)
+                .name("&6&lLobby Music")
+                .lore(
+                        "",
+                        " " + LoreHelper.enabledOrDisabled(profile.getProfileData().getSettingData().isLobbyMusicEnabled()),
+                        "",
+                        "&aClick to change!"
+                )
+                .hideMeta()
+                .build();
+    }
+
+    @Override
+    public void clicked(Player player, ClickType clickType) {
+        if (clickType != ClickType.LEFT) return;
+
+        player.performCommand("togglelobbymusic");
+
+        this.playNeutral(player);
+    }
+}

--- a/src/main/java/dev/revere/alley/profile/menu/setting/PracticeSettingsMenu.java
+++ b/src/main/java/dev/revere/alley/profile/menu/setting/PracticeSettingsMenu.java
@@ -40,13 +40,13 @@ public class PracticeSettingsMenu extends Menu {
             ));
         }
 
-        this.addBorder(buttons, 15, 4);
+        this.addBorder(buttons, 15, 5);
 
         return buttons;
     }
 
     @Override
     public int getSize() {
-        return 9 * 4;
+        return 9 * 5;
     }
 }

--- a/src/main/java/dev/revere/alley/profile/menu/setting/button/PracticeSettingsButton.java
+++ b/src/main/java/dev/revere/alley/profile/menu/setting/button/PracticeSettingsButton.java
@@ -102,6 +102,9 @@ public class PracticeSettingsButton extends Button {
             case ROTTEN_FLESH:
                 player.performCommand("toggleprofanityfilter");
                 break;
+            case JUKEBOX:
+                player.performCommand("togglelobbymusic");
+                break;
             case DIAMOND_SWORD:
                 player.performCommand("toggleduelrequests");
                 break;

--- a/src/main/java/dev/revere/alley/profile/menu/setting/button/PracticeSettingsButton.java
+++ b/src/main/java/dev/revere/alley/profile/menu/setting/button/PracticeSettingsButton.java
@@ -6,6 +6,7 @@ import dev.revere.alley.feature.cosmetic.menu.CosmeticsMenu;
 import dev.revere.alley.profile.IProfileService;
 import dev.revere.alley.profile.Profile;
 import dev.revere.alley.profile.enums.EnumWorldTime;
+import dev.revere.alley.profile.menu.music.MusicDiscSelectorMenu;
 import dev.revere.alley.tool.item.ItemBuilder;
 import dev.revere.alley.util.chat.CC;
 import lombok.AllArgsConstructor;
@@ -103,7 +104,7 @@ public class PracticeSettingsButton extends Button {
                 player.performCommand("toggleprofanityfilter");
                 break;
             case JUKEBOX:
-                player.performCommand("togglelobbymusic");
+                new MusicDiscSelectorMenu().openMenu(player);
                 break;
             case DIAMOND_SWORD:
                 player.performCommand("toggleduelrequests");

--- a/src/main/java/dev/revere/alley/profile/menu/setting/enums/EnumPracticeSettingType.java
+++ b/src/main/java/dev/revere/alley/profile/menu/setting/enums/EnumPracticeSettingType.java
@@ -96,16 +96,6 @@ public enum EnumPracticeSettingType {
             )
     ),
 
-    LOBBY_MUSIC(22, "&6&lLobby Music", Material.JUKEBOX,
-            settings -> Arrays.asList(
-                    "&fListen to lobby music.",
-                    "",
-                    " " + LoreHelper.enabledOrDisabled(settings.isLobbyMusicEnabled()),
-                    "",
-                    "&aClick to change!"
-            )
-    ),
-
     MATCH_SETTINGS(16, "&6&lMatch Settings", Material.BOOK,
             settings -> Arrays.asList(
                     "&fAdjust your match settings.",
@@ -120,7 +110,17 @@ public enum EnumPracticeSettingType {
                     "",
                     "&aClick to view!"
             )
-    );
+    ),
+
+    LOBBY_MUSIC(34, "&6&lLobby Music", Material.JUKEBOX,
+            settings -> Arrays.asList(
+                    "&fCustomize your lobby music.",
+                    "",
+                    "&aClick to customize!"
+            )
+    ),
+
+    ;
 
     public final int slot;
     public final String displayName;

--- a/src/main/java/dev/revere/alley/profile/menu/setting/enums/EnumPracticeSettingType.java
+++ b/src/main/java/dev/revere/alley/profile/menu/setting/enums/EnumPracticeSettingType.java
@@ -96,6 +96,16 @@ public enum EnumPracticeSettingType {
             )
     ),
 
+    LOBBY_MUSIC(22, "&6&lLobby Music", Material.JUKEBOX,
+            settings -> Arrays.asList(
+                    "&fListen to lobby music.",
+                    "",
+                    " " + LoreHelper.enabledOrDisabled(settings.isLobbyMusicEnabled()),
+                    "",
+                    "&aClick to change!"
+            )
+    ),
+
     MATCH_SETTINGS(16, "&6&lMatch Settings", Material.BOOK,
             settings -> Arrays.asList(
                     "&fAdjust your match settings.",

--- a/src/main/java/dev/revere/alley/provider/scoreboard/impl/QueueScoreboard.java
+++ b/src/main/java/dev/revere/alley/provider/scoreboard/impl/QueueScoreboard.java
@@ -7,6 +7,7 @@ import dev.revere.alley.profile.IProfileService;
 import dev.revere.alley.profile.Profile;
 import dev.revere.alley.profile.enums.EnumProfileState;
 import dev.revere.alley.provider.scoreboard.IScoreboard;
+import dev.revere.alley.util.TimeUtil;
 import dev.revere.alley.util.chat.CC;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -36,7 +37,7 @@ public class QueueScoreboard implements IScoreboard {
                     .replaceAll("\\{wins}", String.valueOf(profile.getProfileData().getTotalWins()))
                     .replaceAll("\\{queued-type}", profile.getQueueProfile().getQueue().getQueueType())
                     .replaceAll("\\{level}", String.valueOf(levelService.getLevel(profile.getProfileData().getGlobalLevel()).getDisplayName()))
-                    .replaceAll("\\{queued-time}", profile.getQueueProfile().getFormattedElapsedTime())
+                    .replaceAll("\\{queued-time}", TimeUtil.getFormattedElapsedTime(profile.getQueueProfile().getElapsedTime()))
                     .replaceAll("\\{dot-animation}", this.getDotAnimation().getCurrentFrame())
                     .replaceAll("\\{queued-kit}", profile.getQueueProfile().getQueue().getKit().getDisplayName())
             );

--- a/src/main/java/dev/revere/alley/tool/visual/LoreHelper.java
+++ b/src/main/java/dev/revere/alley/tool/visual/LoreHelper.java
@@ -1,5 +1,6 @@
 package dev.revere.alley.tool.visual;
 
+import com.avaje.ebeaninternal.server.lib.util.StringHelper;
 import dev.revere.alley.Alley;
 import dev.revere.alley.api.constant.IPluginConstant;
 import lombok.experimental.UtilityClass;
@@ -13,6 +14,16 @@ import org.bukkit.entity.Player;
  */
 @UtilityClass
 public class LoreHelper {
+    /**
+     * Returns a string representation of a boolean value indicating toggled status.
+     *
+     * @param value The boolean value to represent.
+     * @return A formatted string indicating whether the feature is toggled or not.
+     */
+    public String toggledOrNot(boolean value) {
+        String returnValue = value ? "&a&l✔ &6Toggled" : "&c&l✘ &cNot Toggled";
+        return ChatColor.translateAlternateColorCodes('&', "&f&l┃ " + returnValue);
+    }
     /**
      * Returns a string representation of a boolean value.
      *

--- a/src/main/java/dev/revere/alley/util/TimeUtil.java
+++ b/src/main/java/dev/revere/alley/util/TimeUtil.java
@@ -58,6 +58,29 @@ public final class TimeUtil {
     }
 
     /**
+     * Converts elapsed milliseconds to a formatted time string in "mm:ss" format.
+     *
+     * @param elapsedMillis the elapsed time in milliseconds.
+     * @return the formatted time string.
+     */
+    public String getFormattedElapsedTime(long elapsedMillis) {
+        long elapsedSeconds = elapsedMillis / 1000;
+        return String.format("%02d:%02d", elapsedSeconds / 60, elapsedSeconds % 60);
+    }
+
+    /**
+     * Converts a total number of seconds into a formatted time string in "mm:ss" format.
+     *
+     * @param totalSeconds the total number of seconds to convert.
+     * @return the formatted time string in "mm:ss" format.
+     */
+    public static String formatTimeFromSeconds(int totalSeconds) {
+        int minutes = totalSeconds / 60;
+        int seconds = totalSeconds % 60;
+        return String.format("%02d:%02d", minutes, seconds);
+    }
+
+    /**
      * Converts a date to a string.
      *
      * @param date the date to convert.

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -194,6 +194,7 @@ player-settings:
   tablist: "&aYou've {status} &athe tablist."
   profanity-filter: "&aYou've {status} &athe profanity filter."
   duel-requests: "&aYou've {status} &areceiving duel requests."
+  lobby-music: "&aYou've {status} &alobby music."
 
 rename-item:
   missing-arguments: "&cMissing arguments! Please enter a name for the item."

--- a/src/main/resources/providers/scoreboard.yml
+++ b/src/main/resources/providers/scoreboard.yml
@@ -38,16 +38,22 @@ scoreboard:
     - "&6play.revere.dev"
     - "{sidebar}"
   lines:
+    music:
+      - ""
+      - "&6&lMusic"
+      - " &f&l● &rSong: &6{song-name}"
+      - " &f&l● &rDuration: &6{song-duration}"
     lobby:
       - "{sidebar}"
       - "&6&lServer"
       - " &f&l● &rOnline: &6{online}"
       - " &f&l● &rPlaying: &6{playing}"
-      #      - " &f&l● &rIn Queue: &6{in-queue}"
+      - " &f&l● &rIn Queue: &6{in-queue}"
       - ""
       - "&6&lStats"
       - " &f&l● &rWins: &6{wins}"
       - " &f&l● &rLevel: &6{level}"
+      - "{music}"
     party:
       - "{sidebar}"
       - "&6&lParty &7({party-privacy}&7)"


### PR DESCRIPTION
Players can customize their experience by selecting a personal playlist of their favorite in-game music discs. When the feature is enabled, a random song from their selection will play, appearing to emanate from the spawn location for an ambient feel. The system is state-aware, automatically pausing when a player enters a match and restarting when they return to the lobby.

This PR also includes a brand new cooldown functionality that is re-usable for all commands.