### PR TITLE
Issue: Duel Command cannot find available arena for type standalone

### DIFF
--- a/src/main/java/dev/revere/alley/game/duel/DuelRequestServiceImpl.java
+++ b/src/main/java/dev/revere/alley/game/duel/DuelRequestServiceImpl.java
@@ -74,7 +74,7 @@ public class DuelRequestServiceImpl implements DuelRequestService {
 
         Arena finalArena = arena != null ? arena : this.arenaService.getRandomArena(kit);
         if (finalArena instanceof StandAloneArena) {
-            finalArena = this.arenaService.getArenaByName(finalArena.getName());
+            finalArena = this.arenaService.getArenaByName(((StandAloneArena) finalArena).getOriginalArenaName());
         }
 
         if (finalArena == null) {


### PR DESCRIPTION
This simply fixes the duel command (as a non donator player).