### PR TITLE
Fix /duel command for arena selection

### DIFF
--- a/src/main/java/dev/revere/alley/game/duel/DuelRequestServiceImpl.java
+++ b/src/main/java/dev/revere/alley/game/duel/DuelRequestServiceImpl.java
@@ -73,7 +73,7 @@ public class DuelRequestServiceImpl implements DuelRequestService {
         }
 
         Arena finalArena = arena != null ? arena : this.arenaService.getRandomArena(kit);
-        if (finalArena instanceof StandAloneArena) {
+        if (finalArena instanceof StandAloneArena && ((StandAloneArena) finalArena).getOriginalArenaName() != null) {
             finalArena = this.arenaService.getArenaByName(((StandAloneArena) finalArena).getOriginalArenaName());
         }
 


### PR DESCRIPTION
This PR fixes the /duel command whenever you have permission to select a map of your choice. Previously, it would attempt to get the original name of an arena without said value causing a nullpointer.