### PR TITLE
fix: Monkey suit going out of the cosmetic's interface

### DIFF
--- a/src/main/java/dev/revere/alley/feature/cosmetic/internal/repository/impl/suit/MonkeySuit.java
+++ b/src/main/java/dev/revere/alley/feature/cosmetic/internal/repository/impl/suit/MonkeySuit.java
@@ -23,7 +23,7 @@ import java.util.Map;
         name = "Monkey",
         description = "Unleash your inner primate as a monkey.",
         icon = Material.VINE,
-        slot = 17,
+        slot = 19,
         price = 1000
 )
 public class MonkeySuit extends BaseSuit {


### PR DESCRIPTION
PATCH

This PR fixes the Monkey Suit getting out of the box for cosmetics.
<img width="616" height="329" alt="image" src="https://github.com/user-attachments/assets/37950111-a35d-4503-abac-8c6963d7015a" />
