### PR TITLE
chore: fix the most import doc file header in the entire source

### DIFF
--- a/src/main/java/dev/revere/alley/AlleyPlugin.java
+++ b/src/main/java/dev/revere/alley/AlleyPlugin.java
@@ -17,7 +17,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Alley – A modern, modular Practice PvP knockback built from the ground up for Minecraft 1.8.
+ * Alley – A modern, modular Practice PvP core built from the ground up for Minecraft 1.8.
  * <p>
  * Developed by Revere Inc., Alley focuses on clean, professional, and readable code,
  * making it easy for developers to jump into practice PvP development with minimal friction.


### PR DESCRIPTION
Alley is now a "Practice PvP **core**", not a "Practice PvP **knockback**".