### PR TITLE
feat: expand on arena condition check

### DIFF
--- a/src/main/java/dev/revere/alley/feature/arena/ArenaService.java
+++ b/src/main/java/dev/revere/alley/feature/arena/ArenaService.java
@@ -1,5 +1,6 @@
 package dev.revere.alley.feature.arena;
 
+import dev.revere.alley.feature.arena.internal.ArenaServiceImpl;
 import dev.revere.alley.feature.arena.internal.types.StandAloneArena;
 import dev.revere.alley.feature.kit.Kit;
 import dev.revere.alley.bootstrap.lifecycle.Service;
@@ -85,4 +86,11 @@ public interface ArenaService extends Service {
      * @param arena The new arena to add.
      */
     void registerNewArena(Arena arena);
+
+    /**
+     * Provides access to the internal arena validator for external validation needs.
+     *
+     * @return The ArenaValidator instance.
+     */
+    ArenaValidator getArenaValidator();
 }

--- a/src/main/java/dev/revere/alley/feature/arena/ArenaValidator.java
+++ b/src/main/java/dev/revere/alley/feature/arena/ArenaValidator.java
@@ -1,0 +1,66 @@
+package dev.revere.alley.feature.arena;
+
+import dev.revere.alley.AlleyPlugin;
+import dev.revere.alley.common.text.CC;
+import dev.revere.alley.feature.arena.internal.types.StandAloneArena;
+import dev.revere.alley.feature.kit.Kit;
+import dev.revere.alley.feature.kit.KitService;
+import dev.revere.alley.feature.kit.setting.types.mode.KitSettingBridges;
+import dev.revere.alley.feature.kit.setting.types.mode.KitSettingRounds;
+import org.bukkit.entity.Player;
+
+/**
+ * @author Emmy
+ * @project alley-practice
+ * @since 07/09/2025
+ */
+public class ArenaValidator {
+    /**
+     * Validates if an arena is fully configured before enabling or disabling it.
+     * Sends appropriate messages to the player if validation fails.
+     *
+     * @param player the player attempting to enable/disable the arena
+     * @param arena  the arena to be validated
+     * @return true if the arena is fully configured, false otherwise
+     */
+    public boolean isEligible(Player player, Arena arena) {
+        if (arena.getMinimum() == null || arena.getMaximum() == null) {
+            player.sendMessage(CC.translate("&cYou must set both the minimum and maximum points for this arena before toggling! (/arena wand)"));
+            return false;
+        }
+
+        if (arena.getPos1() == null || arena.getPos2() == null) {
+            player.sendMessage(CC.translate("&cYou must set both spawn positions for this arena before toggling! (/arena setspawn)"));
+            return false;
+        }
+
+        if (arena.getCenter() == null) {
+            player.sendMessage(CC.translate("&cYou must set the center point for this arena before toggling! (/arena setcenter)"));
+            return false;
+        }
+
+        if (arena.getKits().isEmpty()) {
+            player.sendMessage(CC.translate("&cYou must add at least one kit to this arena before toggling!"));
+            return false;
+        }
+
+        KitService kitService = AlleyPlugin.getInstance().getService(KitService.class);
+        for (String kitName : arena.getKits()) {
+            Kit kit = kitService.getKit(kitName);
+            if (kit == null) {
+                player.sendMessage(CC.translate("&cThe kit &6" + kitName + " &cassigned to this arena does not exist! Please remove it before toggling."));
+                return false;
+            }
+
+            if (arena.getType() == ArenaType.STANDALONE) {
+                StandAloneArena standAloneArena = (StandAloneArena) arena;
+                if ((kit.isSettingEnabled(KitSettingRounds.class) || kit.isSettingEnabled(KitSettingBridges.class)) && (standAloneArena.getTeam1Portal() == null || standAloneArena.getTeam2Portal() == null)) {
+                    player.sendMessage(CC.translate("&cYou must set both team portals for this arena before toggling! (/arena setportal)"));
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/dev/revere/alley/feature/arena/command/impl/data/ArenaToggleCommand.java
+++ b/src/main/java/dev/revere/alley/feature/arena/command/impl/data/ArenaToggleCommand.java
@@ -1,5 +1,7 @@
 package dev.revere.alley.feature.arena.command.impl.data;
 
+import dev.revere.alley.feature.arena.ArenaValidator;
+import dev.revere.alley.feature.arena.internal.ArenaServiceImpl;
 import dev.revere.alley.library.command.BaseCommand;
 import dev.revere.alley.library.command.CommandArgs;
 import dev.revere.alley.library.command.annotation.CommandData;
@@ -56,13 +58,8 @@ public class ArenaToggleCommand extends BaseCommand {
             return;
         }
 
-        if (arena.getMinimum() == null || arena.getMaximum() == null || arena.getPos1() == null || arena.getPos2() == null) {
-            player.sendMessage(CC.translate("&cYou must finish configuring this arena before enabling or disabling!"));
-            return;
-        }
-
-        if (arena.getKits().isEmpty()) {
-            player.sendMessage(CC.translate("&cYou must add at least one kit to this arena before enabling or disabling!"));
+        ArenaValidator validator = arenaService.getArenaValidator();
+        if (!validator.isEligible(player, arena)) {
             return;
         }
 

--- a/src/main/java/dev/revere/alley/feature/arena/internal/ArenaServiceImpl.java
+++ b/src/main/java/dev/revere/alley/feature/arena/internal/ArenaServiceImpl.java
@@ -1,24 +1,28 @@
 package dev.revere.alley.feature.arena.internal;
 
 import dev.revere.alley.AlleyPlugin;
+import dev.revere.alley.bootstrap.AlleyContext;
+import dev.revere.alley.bootstrap.annotation.Service;
+import dev.revere.alley.common.FileUtil;
+import dev.revere.alley.common.VoidChunkGenerator;
+import dev.revere.alley.common.logger.Logger;
+import dev.revere.alley.common.serializer.Serializer;
+import dev.revere.alley.core.config.ConfigService;
 import dev.revere.alley.feature.arena.Arena;
 import dev.revere.alley.feature.arena.ArenaService;
 import dev.revere.alley.feature.arena.ArenaType;
+import dev.revere.alley.feature.arena.ArenaValidator;
 import dev.revere.alley.feature.arena.internal.types.FreeForAllArena;
 import dev.revere.alley.feature.arena.internal.types.SharedArena;
 import dev.revere.alley.feature.arena.internal.types.StandAloneArena;
 import dev.revere.alley.feature.arena.schematic.ArenaSchematicService;
-import dev.revere.alley.feature.kit.KitService;
 import dev.revere.alley.feature.kit.Kit;
-import dev.revere.alley.core.config.ConfigService;
-import dev.revere.alley.bootstrap.AlleyContext;
-import dev.revere.alley.bootstrap.annotation.Service;
-import dev.revere.alley.common.logger.Logger;
-import dev.revere.alley.common.serializer.Serializer;
-import dev.revere.alley.common.FileUtil;
-import dev.revere.alley.common.VoidChunkGenerator;
+import dev.revere.alley.feature.kit.KitService;
 import lombok.Getter;
-import org.bukkit.*;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.WorldCreator;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 
@@ -54,6 +58,8 @@ public class ArenaServiceImpl implements ArenaService {
     private World temporaryWorld;
     private Location nextCopyLocation;
     private final int arenaSpacing = 1500;
+
+    private final ArenaValidator arenaValidator = new ArenaValidator();
 
     public ArenaServiceImpl(AlleyPlugin plugin, ConfigService configService, KitService kitService, ArenaSchematicService arenaSchematicService) {
         this.plugin = plugin;


### PR DESCRIPTION
This PR adds an ArenaValidator to ensure arenas are fully configured before being toggled.

- Validates spawn positions, center, kits, and portals (when required by kit settings).
- Prevents arenas with missing or invalid setups from being enabled.
- Provides players with clear, descriptive error messages on failed checks.