### PR TITLE
chore: join listener exception fixed

### DIFF
--- a/src/main/java/dev/revere/alley/AlleyPlugin.java
+++ b/src/main/java/dev/revere/alley/AlleyPlugin.java
@@ -1,17 +1,16 @@
 package dev.revere.alley;
 
-import dev.revere.alley.core.config.ConfigService;
 import dev.revere.alley.bootstrap.AlleyContext;
 import dev.revere.alley.bootstrap.lifecycle.Service;
+import dev.revere.alley.common.logger.Logger;
+import dev.revere.alley.common.logger.PluginLogger;
+import dev.revere.alley.core.database.task.RepositoryCleanupTask;
 import dev.revere.alley.core.locale.LocaleService;
 import dev.revere.alley.core.locale.internal.impl.VisualsLocaleImpl;
 import dev.revere.alley.feature.cosmetic.task.CosmeticTask;
-import dev.revere.alley.visual.tablist.task.TablistUpdateTask;
 import dev.revere.alley.feature.match.task.other.ArrowRemovalTask;
 import dev.revere.alley.feature.match.task.other.MatchPearlCooldownTask;
-import dev.revere.alley.core.database.task.RepositoryCleanupTask;
-import dev.revere.alley.common.logger.Logger;
-import dev.revere.alley.common.logger.PluginLogger;
+import dev.revere.alley.visual.tablist.task.TablistUpdateTask;
 import lombok.Getter;
 import org.bukkit.plugin.java.JavaPlugin;
 

--- a/src/main/java/dev/revere/alley/core/profile/Profile.java
+++ b/src/main/java/dev/revere/alley/core/profile/Profile.java
@@ -24,7 +24,6 @@ import dev.revere.alley.feature.queue.QueueProfile;
 import dev.revere.alley.feature.queue.QueueType;
 import lombok.Getter;
 import lombok.Setter;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 
 import java.util.*;
@@ -63,13 +62,14 @@ public class Profile {
      * Constructor for the Profile class.
      *
      * @param uuid The UUID of the player.
+     * @param name The name of the player.
      */
-    public Profile(UUID uuid) {
+    public Profile(UUID uuid, String name) {
         this.uuid = uuid;
         this.firstJoin = System.currentTimeMillis();
         this.state = ProfileState.LOBBY;
         this.profileData = new ProfileData();
-        this.name = Bukkit.getOfflinePlayer(this.uuid).getName();
+        this.name = name;
         this.leaderboardType = LeaderboardType.RANKED;
         this.queueType = QueueType.UNRANKED;
         this.nameColor = ChatColor.WHITE;

--- a/src/main/java/dev/revere/alley/core/profile/internal/ProfileServiceImpl.java
+++ b/src/main/java/dev/revere/alley/core/profile/internal/ProfileServiceImpl.java
@@ -1,6 +1,7 @@
 package dev.revere.alley.core.profile.internal;
 
 import com.mongodb.client.MongoCollection;
+import dev.revere.alley.AlleyPlugin;
 import dev.revere.alley.bootstrap.AlleyContext;
 import dev.revere.alley.bootstrap.annotation.Service;
 import dev.revere.alley.common.logger.Logger;
@@ -58,7 +59,8 @@ public class ProfileServiceImpl implements ProfileService {
     @Override
     public Profile getProfile(UUID uuid) {
         return this.profiles.computeIfAbsent(uuid, k -> {
-            Profile profile = new Profile(k);
+            String name = AlleyPlugin.getInstance().getServer().getOfflinePlayer(k).getName();
+            Profile profile = new Profile(k, name);
             profile.load();
             return profile;
         });

--- a/src/main/java/dev/revere/alley/core/profile/listener/ProfileListener.java
+++ b/src/main/java/dev/revere/alley/core/profile/listener/ProfileListener.java
@@ -46,15 +46,17 @@ public class ProfileListener implements Listener {
             return;
         }
 
+        Player player = event.getPlayer();
+
         if (event.getResult() != PlayerLoginEvent.Result.ALLOWED) {
             return;
         }
 
-        Profile profile = new Profile(event.getPlayer().getUniqueId());
+        Profile profile = new Profile(player.getUniqueId(), player.getName());
         profile.load();
 
         ProfileService profileService = AlleyPlugin.getInstance().getService(ProfileService.class);
-        profileService.getProfile(event.getPlayer().getUniqueId());
+        profileService.getProfile(player.getUniqueId());
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)


### PR DESCRIPTION
The previous logic relying on Bukkit.getOfflinePlayer(uuid).getName() could return null for players joining for the very first time, causing a validation error when the new profile was immediately saved to the database.